### PR TITLE
Fix JSON model binding issue in API controllers

### DIFF
--- a/Server/Controllers/AppointmentController.cs
+++ b/Server/Controllers/AppointmentController.cs
@@ -4,6 +4,7 @@ using EMR.Server.Models;
 using EMR.Server.Services;
 using Hl7.Fhir.Model;
 using Hl7.Fhir.Serialization;
+using System.Text.Json;
 
 namespace EMR.Server.Controllers
 {
@@ -72,10 +73,11 @@ namespace EMR.Server.Controllers
 
         // POST: fhir/Appointment
         [HttpPost]
-        public async Task<ActionResult<string>> CreateAppointment([FromBody] string appointmentJson)
+        public async Task<ActionResult<string>> CreateAppointment([FromBody] JsonElement appointmentJsonElement)
         {
             try
             {
+                var appointmentJson = appointmentJsonElement.GetRawText();
                 var parser = new FhirJsonParser();
                 var appointment = parser.Parse<Appointment>(appointmentJson);
                 
@@ -107,7 +109,7 @@ namespace EMR.Server.Controllers
 
         // PUT: fhir/Appointment/{id}
         [HttpPut("{id}")]
-        public async Task<ActionResult<string>> UpdateAppointment(string id, [FromBody] string appointmentJson)
+        public async Task<ActionResult<string>> UpdateAppointment(string id, [FromBody] JsonElement appointmentJsonElement)
         {
             try
             {
@@ -117,6 +119,7 @@ namespace EMR.Server.Controllers
                     return NotFound();
                 }
 
+                var appointmentJson = appointmentJsonElement.GetRawText();
                 var parser = new FhirJsonParser();
                 var appointment = parser.Parse<Appointment>(appointmentJson);
                 appointment.Id = id; // Ensure the ID matches

--- a/Server/Controllers/EncounterController.cs
+++ b/Server/Controllers/EncounterController.cs
@@ -4,6 +4,7 @@ using EMR.Server.Models;
 using EMR.Server.Services;
 using Hl7.Fhir.Model;
 using Hl7.Fhir.Serialization;
+using System.Text.Json;
 
 namespace EMR.Server.Controllers
 {
@@ -73,10 +74,11 @@ namespace EMR.Server.Controllers
 
         // POST: fhir/Encounter
         [HttpPost]
-        public async Task<ActionResult<string>> CreateEncounter([FromBody] string encounterJson)
+        public async Task<ActionResult<string>> CreateEncounter([FromBody] JsonElement encounterJsonElement)
         {
             try
             {
+                var encounterJson = encounterJsonElement.GetRawText();
                 var parser = new FhirJsonParser();
                 var encounter = parser.Parse<Encounter>(encounterJson);
                 
@@ -108,7 +110,7 @@ namespace EMR.Server.Controllers
 
         // PUT: fhir/Encounter/{id}
         [HttpPut("{id}")]
-        public async Task<ActionResult<string>> UpdateEncounter(string id, [FromBody] string encounterJson)
+        public async Task<ActionResult<string>> UpdateEncounter(string id, [FromBody] JsonElement encounterJsonElement)
         {
             try
             {
@@ -118,6 +120,7 @@ namespace EMR.Server.Controllers
                     return NotFound();
                 }
 
+                var encounterJson = encounterJsonElement.GetRawText();
                 var parser = new FhirJsonParser();
                 var encounter = parser.Parse<Encounter>(encounterJson);
                 encounter.Id = id; // Ensure the ID matches

--- a/Server/Controllers/PatientController.cs
+++ b/Server/Controllers/PatientController.cs
@@ -4,6 +4,7 @@ using EMR.Server.Models;
 using EMR.Server.Services;
 using Hl7.Fhir.Model;
 using Hl7.Fhir.Serialization;
+using System.Text.Json;
 
 namespace EMR.Server.Controllers
 {
@@ -70,11 +71,12 @@ namespace EMR.Server.Controllers
 
         // POST: fhir/Patient
         [HttpPost]
-        public async Task<ActionResult<string>> CreatePatient([FromBody] string patientJson)
+        public async Task<ActionResult<string>> CreatePatient([FromBody] JsonElement patientJsonElement)
         {
             try
             {
                 _logger.LogDebug("In PATIENT CONTROLLER -------------------------------------------------------");
+                var patientJson = patientJsonElement.GetRawText();
                 var parser = new FhirJsonParser();
                 var patient = parser.Parse<Patient>(patientJson);
                 
@@ -99,7 +101,7 @@ namespace EMR.Server.Controllers
 
         // PUT: fhir/Patient/{id}
         [HttpPut("{id}")]
-        public async Task<ActionResult<string>> UpdatePatient(string id, [FromBody] string patientJson)
+        public async Task<ActionResult<string>> UpdatePatient(string id, [FromBody] JsonElement patientJsonElement)
         {
             try
             {
@@ -109,6 +111,7 @@ namespace EMR.Server.Controllers
                     return NotFound();
                 }
 
+                var patientJson = patientJsonElement.GetRawText();
                 var parser = new FhirJsonParser();
                 var patient = parser.Parse<Patient>(patientJson);
                 patient.Id = id; // Ensure the ID matches


### PR DESCRIPTION
- Changed [FromBody] string parameters to JsonElement in all POST/PUT endpoints
- Added System.Text.Json using statements to controllers
- Fixed CreatePatient, UpdatePatient, CreateEncounter, UpdateEncounter, CreateAppointment, and UpdateAppointment methods
- This resolves the model binding error that prevented JSON objects from being properly bound to string parameters